### PR TITLE
Adicionado parâmetro --cov-report=xml

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -38,7 +38,7 @@ jobs:
         pipenv run flake8 . --count --exit-zero --max-complexity=10 --statistics
     - name: Test with pytest
       run: |
-        pipenv run pytest --cov pypro
+        pipenv run pytest --cov=./pypro --cov-report=xml
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
Adicionado parâmetro para gerar relatório do codecov no formato xml.

close #18