### PR TITLE
Utilização de url nomeada na página principal

### DIFF
--- a/pypro/base/templates/base/home.html
+++ b/pypro/base/templates/base/home.html
@@ -23,47 +23,9 @@
                                 data-target="#bs-example-navbar-collapse-1">
                             <span class="navbar-toggler-icon"></span>
                         </button>
-                        <a class="navbar-brand" href="#">Brand</a>
+                        <a class="navbar-brand" href="{% url 'home' %}">Python Pro</a>
                         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                             <ul class="navbar-nav">
-                                <li class="nav-item active">
-                                    <a class="nav-link" href="#">Link <span class="sr-only">(current)</span></a>
-                                </li>
-                                <li class="nav-item">
-                                    <a class="nav-link" href="#">Link</a>
-                                </li>
-                                <li class="nav-item dropdown">
-                                    <a class="nav-link dropdown-toggle"
-                                       href="#"
-                                       id="navbarDropdownMenuLink"
-                                       data-toggle="dropdown">Dropdown link</a>
-                                    <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                                        <a class="dropdown-item" href="#">Action</a> <a class="dropdown-item" href="#">Another action</a> <a class="dropdown-item" href="#">Something else here</a>
-                                        <div class="dropdown-divider"></div>
-                                        <a class="dropdown-item" href="#">Separated link</a>
-                                    </div>
-                                </li>
-                            </ul>
-                            <form class="form-inline">
-                                <input class="form-control mr-sm-2" type="text" />
-                                <button class="btn btn-primary my-2 my-sm-0" type="submit">Search</button>
-                            </form>
-                            <ul class="navbar-nav ml-md-auto">
-                                <li class="nav-item active">
-                                    <a class="nav-link" href="#">Link <span class="sr-only">(current)</span></a>
-                                </li>
-                                <li class="nav-item dropdown">
-                                    <a class="nav-link dropdown-toggle"
-                                       href="#"
-                                       id="navbarDropdownMenuLink"
-                                       data-toggle="dropdown">Dropdown link</a>
-                                    <div class="dropdown-menu dropdown-menu-right"
-                                         aria-labelledby="navbarDropdownMenuLink">
-                                        <a class="dropdown-item" href="#">Action</a> <a class="dropdown-item" href="#">Another action</a> <a class="dropdown-item" href="#">Something else here</a>
-                                        <div class="dropdown-divider"></div>
-                                        <a class="dropdown-item" href="#">Separated link</a>
-                                    </div>
-                                </li>
                             </ul>
                         </div>
                     </nav>

--- a/pypro/base/tests/test_home.py
+++ b/pypro/base/tests/test_home.py
@@ -1,12 +1,22 @@
 from django.test import Client
+from django.urls import reverse
+from pytest import fixture
 from pypro.django_assertions import assert_contains
 
 
-def test_status_code(client: Client):
-    resp = client.get('/')
-    assert resp.status_code == 200
+@fixture
+def response(client: Client):
+    resp = client.get(reverse('home'))
+    return resp
 
 
-def test_title(client: Client):
-    resp = client.get('/')
-    assert_contains(resp, '<title>Python Pro</title>')
+def test_status_code(response):
+    assert response.status_code == 200
+
+
+def test_title(response):
+    assert_contains(response, '<title>Python Pro</title>')
+
+
+def test_home_link(response):
+    assert_contains(response, f'href="{reverse("home")}">Python Pro</a>')


### PR DESCRIPTION
Criado teste para confirmar a existência de um link na navbar
direcionado para a página princial.
Alterado o template da página principal para gerar o link independente o
endpoint definido para a página princial.

close #48