### PR TITLE
Adicionado filtro no título do vídeo

### DIFF
--- a/pypro/aperitivos/templates/aperitivos/video.html
+++ b/pypro/aperitivos/templates/aperitivos/video.html
@@ -6,7 +6,7 @@
 <div class="row">
     <div class="col">
         <div class="container rounded mt-4 mb-3">
-            <h1 class="h1">{{ video.titulo }}</h1>
+            <h1 class="h1">{{ video.titulo | default:'Faltando título' }}</h1>
             <iframe src="https://player.vimeo.com/video/{{ video.vimeo_id }}" width="640" height="564" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
         </div>
     </div>


### PR DESCRIPTION
Adicionado filtro [default](https://docs.djangoproject.com/en/4.0/ref/templates/builtins/#default) para exibir um texto padrão quando o título do vídeo não for informado.

close #66