### PR TITLE
Formulário para redefinição de senha

### DIFF
--- a/contrib/env-sample
+++ b/contrib/env-sample
@@ -2,12 +2,21 @@ SECRET_KEY='your-secret-key-here'
 DEBUG=False
 ALLOWED_HOSTS='localhost,127.0.0.1'
 DATABASE_URL='postgres://postgres:postgres@localhost/testdb'
+INTERNAL_IPS='127.0.0.1'
 
+# AWS
 AWS_ACCESS_KEY_ID=''
 AWS_SECRET_ACCESS_KEY=''
 AWS_STORAGE_BUCKET_NAME=''
 AWS_S3_REGION_NAME=''
 
-INTERNAL_IPS='127.0.0.1'
-
+# Sentry
 SENTRY_DSN=''
+
+# Configuração de email
+EMAIL_BACKEND='django.core.mail.backends.console.EmailBackend'
+EMAIL_HOST='localhost'
+EMAIL_PORT='25'
+EMAIL_HOST_USER=''
+EMAIL_HOST_PASSWORD=''
+EMAIL_USE_TLS=True

--- a/pypro/base/templates/registration/login.html
+++ b/pypro/base/templates/registration/login.html
@@ -1,5 +1,5 @@
-{% extends 'base/base.html' %}
-{% load static %}
+{% extends "base/base.html" %}
+{% load i18n static %}
 {% block title %}Python Pro - Login{% endblock title %}
 {% block body %}
 <div class="container">

--- a/pypro/base/templates/registration/passwd_reset_form.html
+++ b/pypro/base/templates/registration/passwd_reset_form.html
@@ -1,0 +1,26 @@
+{% extends 'base/base.html' %}
+{% load i18n static %}
+{% block title %}Python Pro - {% translate 'Password reset' %}{% endblock title %}
+{% block body %}
+<div class="container">
+    <div class="row">
+        <div class="col-auto">
+            <div class="container bg-light rounded mt-3 mb-3 p-3">
+                <p>{% translate 'Forgotten your password? Enter your email address below, and we’ll email instructions for setting a new one.' %}</p>
+
+                <form method="post">{% csrf_token %}
+                    <fieldset class="module aligned">
+                        <div class="form-row field-email">
+                            {{ form.email.errors }}
+                            <label for="id_email">{% translate 'Email address:' %}</label>
+                            {{ form.email }}
+                        </div>
+                        <input type="submit" value="{% translate 'Reset my password' %}">
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/pypro/settings.py
+++ b/pypro/settings.py
@@ -83,6 +83,14 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "pypro.wsgi.application"
 
+# Configurações para envio de email
+EMAIL_BACKEND = config("EMAIL_BACKEND")
+EMAIL_HOST = config("EMAIL_HOST")
+EMAIL_PORT = config("EMAIL_PORT")
+EMAIL_HOST_USER = config("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD")
+EMAIL_USE_TLS = config("EMAIL_USE_TLS")
+
 # Django Debug Toolbar
 INTERNAL_IPS = config("INTERNAL_IPS", default="127.0.0.1", cast=Csv())
 if DEBUG:

--- a/pypro/urls.py
+++ b/pypro/urls.py
@@ -14,12 +14,16 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
+from django.contrib.auth import views as auth_views
 from django.conf import settings
 from django.urls import path, include
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("contas/", include("django.contrib.auth.urls")),
+    path("contas/", include([
+        path("password_reset/", auth_views.PasswordResetView.as_view(template_name="registration/passwd_reset_form.html"), name="password_reset"),
+        path("", include("django.contrib.auth.urls"))
+    ])),
     path("", include("pypro.base.urls")),
     path("aperitivos/", include("pypro.aperitivos.urls")),
     path("modulos/", include("pypro.modulos.urls")),


### PR DESCRIPTION
Foi criado um formulário personalizado para redefinição da senha do
usuário em substituição ao formulário padrão que possui a identidade
visual do painel administrativo do django.
Também foram criadas configurações do servidor de email usado para
enviar o link de redefinição de senha para o email do usuário.

close #103